### PR TITLE
upgrade to nom 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ keywords = ["semver", "semantic", "version", "versioning"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-"nom" = "1.2.*"
+"nom" = "^2.0"
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -93,12 +93,12 @@ named!(
 #[allow(dead_code)]
 named!(
     version<&[u8], Version>,
-    chain!(
-        major: number ~
-        minor: next_number ~
-        patch: next_number ~
-        extensions: extensions,
-        || {
+    do_parse!(
+           major:      number
+        >> minor:      next_number
+        >> patch:      next_number
+        >> extensions: extensions
+        >> (
             Version {
                 major: major,
                 minor: minor,
@@ -106,7 +106,7 @@ named!(
                 pre: extensions.0.clone().unwrap_or(Vec::new()),
                 build: extensions.1.clone().unwrap_or(Vec::new()),
             }
-        }
+        )
     )
 );
 


### PR DESCRIPTION
Hi!

as a part of the release process for nom 2.0, I selected a few crates to test it with, and make sure everything works correctly.

I'm happy to tell you that this crate built fine with nom 2.0 out of the box, no need to change anything!

If you want more information on this release, see the blogpost: https://unhandledexpression.com/2016/11/25/this-year-in-nom-2-0-is-here/ (reddit discussion: https://www.reddit.com/r/rust/comments/5espfm/this_year_in_nom_20_is_here/ )

There are a few new features that could be of interest for this project :)